### PR TITLE
fix: model without reducers lose state

### DIFF
--- a/packages/dva-core/src/index.js
+++ b/packages/dva-core/src/index.js
@@ -74,10 +74,8 @@ export function create(hooksAndOpts = {}, createOpts = {}) {
     model(m);
 
     const store = app._store;
-    if (m.reducers) {
-      store.asyncReducers[m.namespace] = getReducer(m.reducers, m.state);
-      store.replaceReducer(createReducer(store.asyncReducers));
-    }
+    store.asyncReducers[m.namespace] = getReducer(m.reducers, m.state);
+    store.replaceReducer(createReducer(store.asyncReducers));
     if (m.effects) {
       store.runSaga(app._getSaga(m.effects, m, onError, plugin.get('onEffect')));
     }


### PR DESCRIPTION
例子：https://github.com/dgeibi/dva-hot

```
$ npm run example
```

打开 http://localhost:8080/#/model-one

一个无 reducers 的 model 的 state 原来是一个数，热替换后应该是一个随机数，但实际是 undefined ：

![deepinscreenshot_select-area_20180119122402](https://user-images.githubusercontent.com/2224764/35134817-cc88513c-fd13-11e7-9d12-6a3c407dd03e.png)
